### PR TITLE
Add keyframe map to boost performance

### DIFF
--- a/bvhio/lib/Parser.py
+++ b/bvhio/lib/Parser.py
@@ -1,9 +1,10 @@
+import errno
 import os
+from io import TextIOWrapper
+from typing import Optional
+
 import glm
 import numpy
-import errno
-
-from io import TextIOWrapper
 from SpatialTransform import Euler, Pose, Transform
 
 from .bvh import *
@@ -91,8 +92,12 @@ def convertBvhToHierarchy(bvh: BvhJoint) -> Joint:
     return joint
 
 
-def convertHierarchyToBvh(joint: Joint, frames: int, worldSpace: Pose = Pose()) -> BvhJoint:
+def convertHierarchyToBvh(joint: Joint, frames: int, worldSpace: Optional[Pose] = None) -> BvhJoint:
     """Converts a joint structure into a deseralized bvh structure."""
+
+    if worldSpace is None:
+        worldSpace = Pose()
+
     bvh = BvhJoint(joint.Name)
     bvh.Offset = worldSpace.Space * joint.RestPose.Position
     bvh.EndSite = (worldSpace.Space * (0, 1, 0)) * glm.length(joint.RestPose.Position) * 0.3


### PR DESCRIPTION
# Changes

- Add `_KeyframeMap` to `Joint` class to have a fast lookup for existing frames
- Skip `bisect_left` call when trying to add a new frame at the end
- Fix a bug when running the script multiple times causes the armature to shift each time

# Description

I've been profiling the project for a large BVH file and noticed that most of the time is taken by binary search and not matrix computations. 

I suggest to add an auxiliary keyframe map that would allow to quickly fetch a key by frame number instead of searching through the sorted array. It also seems that there's no reason to do the search at all for files with "full frame set", i.e. when interpolation is not needed. You can always just get the exact frame by frame number. These changes gave a **5x** performance bost for my sample file (from 363 to 70 seconds).

Here's the profiler output before:

![image](https://user-images.githubusercontent.com/2528805/234317732-c403bc01-51d5-4505-b970-e7054ea36af8.png)

and after:

![image](https://user-images.githubusercontent.com/2528805/234317890-203e43e8-b5a9-424e-87a4-43c2a46ac04d.png)

The code I used to test:

```python
import os

import bvhio

def reset_pose(source: str, destination: str):
    print(f'Loading {os.path.basename(source)}')
    root = bvhio.readAsHierarchy(source)
    layout = root.layout()

    joint_map = {layout[i][0].Name: layout[i][0] for i in range(len(layout))}

    # rest pose correction
    root.loadRestPose()

    joint_map["LeftShoulder"].setEuler((   0,   0,  -90))
    joint_map["RightShoulder"].setEuler((   0,   0,  90))
    joint_map["LeftHandThumb1"].setEuler((   45,   0,  0))
    joint_map["RightHandThumb1"].setEuler((   45,   0,  0))

    root.writeRestPose(recursive=True, keep=['position', 'rotation', 'scale'])

    print('| Write file')
    bvhio.writeHierarchy(path=destination, root=root, frameTime=1/60)

if __name__ == "__main__":
    source = "source.bvh"
    destination = "dest.bvh"
    reset_pose(source, destination)
```

I've also noticed that if I process the file multiple times, it rotates the model ~15 degrees for each consecutive run. The bug is here:

```
def convertHierarchyToBvh(joint: Joint, frames: int, worldSpace: Pose = Pose()) -> BvhJoint:
```

As the pose is initialized only once on script initialization it gets mutated and then reused for the next call. Read more about this common bug [here](https://www.codecademy.com/learn/learn-intermediate-python-3/modules/int-python-function-arguments/cheatsheet). So I replaced it with an optional value.