### PR TITLE
Update version PyGLM to 2.7.1 which fixes problems installing on MacOS.

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -16,7 +16,7 @@ classifiers = [
 ]
 dependencies = [
     'numpy',
-    'PyGLM==2.7.0',
+    'PyGLM==2.7.1',
     'spatial-transform==1.2.13',
 ]
 


### PR DESCRIPTION
Currently, the installation of bvhio fails on some platforms because of problems with PyGLM 2.7.0. These are fixed in 2.7.1, so bump the version.  