### PR TITLE
pyproject.toml: bump PyGLM to 2.8.3 to support Python 3.14

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "bvhio"
-version = "1.5.4"
+version = "1.5.5"
 authors = [ { name="Wasserwecken", email="author@example.com" }, ]
 description = "Read, write, edit and create .bvh files with hierarchical 3D transforms."
 readme = "README.md"
@@ -16,8 +16,8 @@ classifiers = [
 ]
 dependencies = [
     'numpy',
-    'PyGLM==2.8.2',
-    'spatial-transform==1.3.3',
+    'PyGLM==2.8.3',
+    'spatial-transform==1.3.4',
 ]
 
 [project.urls]


### PR DESCRIPTION
@Wasserwecken

Hi! See files listed below - Python 3.14 binaries were added in 2.8.3, so installing `bvhio` on Python 3.14 is currently trying to build `pyglm` instead of using binaries because of `==2.8.2`.

https://pypi.org/project/pyglm/2.8.3/#files
https://pypi.org/project/pyglm/2.8.2/#files
